### PR TITLE
Add map size controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,10 @@ spread of cases from the earliest available date to the most recent one.
 
 ```bash
 pip install pandas folium
-python covid_heatmap.py
+python covid_heatmap.py --last-days 30 --scale 150
 ```
+The optional flags let you limit the number of days displayed and control
+bubble size. Increase `--scale` for smaller bubbles.
 
 Open the resulting `covid_bubble_map.html` file in your browser to visualize the
 cases.

--- a/covid_heatmap.ipynb
+++ b/covid_heatmap.ipynb
@@ -59,12 +59,12 @@
    "execution_count": null,
    "outputs": [],
    "source": [
-    "m = folium.Map(location=[0, 0], zoom_start=2)\n",
-    "TimestampedGeoJson({'type': 'FeatureCollection', 'features': features}, period='P1D', add_last_point=False, auto_play=False).add_to(m)\n",
-    "m.save('covid_bubble_map.html')\n",
+    "b = folium.Map(location=[0, 0], zoom_start=2)\n",
+    "TimestampedGeoJson({'type': 'FeatureCollection', 'features': features}, period='P1D', add_last_point=False, auto_play=False).add_to(b)\n",
+    "b.save('covid_bubble_map.html')\n",
     "print(f'Bubble map saved to covid_bubble_map.html for dates {date_cols[0]} to {date_cols[-1]}.')\n",
-    "m"
-   ]
+    "b"
+  ]
   }
  ],
  "metadata": {

--- a/covid_heatmap.py
+++ b/covid_heatmap.py
@@ -1,29 +1,66 @@
-import pandas as pd
-import folium
-from folium.plugins import TimestampedGeoJson
+"""Generate an interactive COVID-19 bubble map using Folium."""
+
+from __future__ import annotations
+
+import argparse
 from math import sqrt
 
-URL = "https://raw.githubusercontent.com/CSSEGISandData/COVID-19/master/csse_covid_19_data/csse_covid_19_time_series/time_series_covid19_confirmed_global.csv"
+import folium
+import pandas as pd
+from folium.plugins import TimestampedGeoJson
 
-def main():
+URL = (
+    "https://raw.githubusercontent.com/CSSEGISandData/COVID-19/master/"
+    "csse_covid_19_data/csse_covid_19_time_series/"
+    "time_series_covid19_confirmed_global.csv"
+)
+
+
+def parse_args() -> argparse.Namespace:
+    """Return command line arguments."""
+
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--last-days",
+        type=int,
+        default=30,
+        help="Number of recent days to include in the map",
+    )
+    parser.add_argument(
+        "--scale",
+        type=float,
+        default=100.0,
+        help="Bubble size scale factor. Higher values yield smaller bubbles.",
+    )
+    parser.add_argument(
+        "--min-cases",
+        type=int,
+        default=1,
+        help="Minimum number of cases required to display a bubble",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
     data = pd.read_csv(URL)
 
-    # Columns from index 4 onwards contain the daily counts
     date_cols = data.columns[4:]
+    if args.last_days > 0:
+        date_cols = date_cols[-args.last_days :]
 
-    grouped = data.groupby(['Lat', 'Long'])[date_cols].sum().reset_index()
+    grouped = data.groupby(["Lat", "Long"])[date_cols].sum().reset_index()
     iso_dates = pd.to_datetime(date_cols).strftime("%Y-%m-%d")
 
     features = []
-    scale = 100
     for _, row in grouped.iterrows():
-        lat = row['Lat']
-        lon = row['Long']
+        lat = row["Lat"]
+        lon = row["Long"]
         for date, iso in zip(date_cols, iso_dates):
             count = row[date]
-            if count <= 0:
+            if count < args.min_cases:
                 continue
-            radius = max(2, sqrt(count) / scale)
+            radius = max(2, sqrt(count) / args.scale)
             features.append(
                 {
                     "type": "Feature",
@@ -43,17 +80,18 @@ def main():
                 }
             )
 
-    m = folium.Map(location=[0, 0], zoom_start=2)
+    b = folium.Map(location=[0, 0], zoom_start=2, width="80%", height="60%")
     TimestampedGeoJson(
         {"type": "FeatureCollection", "features": features},
         period="P1D",
         add_last_point=False,
         auto_play=False,
-    ).add_to(m)
-    m.save('covid_bubble_map.html')
+    ).add_to(b)
+    b.save("covid_bubble_map.html")
     print(
         f"Bubble map saved to covid_bubble_map.html for dates {date_cols[0]} to {date_cols[-1]}."
     )
+
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Summary
- add CLI flags to control date range, bubble scale and minimum cases
- shrink map dimensions a bit
- document the new arguments in the README
- rename the map variable from `m` to `b`

## Testing
- `python -m py_compile covid_heatmap.py`


------
https://chatgpt.com/codex/tasks/task_e_6841a34c2d708322969b3068429bc893