### PR TITLE
Add dynamic table with date selector

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,10 @@ This repository contains a simple script to generate a COVID-19 bubble map using
 numbers.
 
 The script downloads the confirmed case data and builds an interactive
-bubble map saved as `covid_bubble_map.html`. A date slider lets you explore the
-spread of cases from the earliest available date to the most recent one.
+bubble map saved as `covid_dashboard.html`. A date slider lets you explore the
+spread of cases from the earliest available date to the most recent one. The
+page also includes a dynamic table that updates to show case counts for the
+selected date.
 
 ```bash
 pip install pandas folium
@@ -19,8 +21,8 @@ python covid_heatmap.py --last-days 30 --scale 150
 The optional flags let you limit the number of days displayed and control
 bubble size. Increase `--scale` for smaller bubbles.
 
-Open the resulting `covid_bubble_map.html` file in your browser to visualize the
-cases.
+Open the resulting `covid_dashboard.html` file in your browser to visualize the
+cases and browse the table.
 
 ### Jupyter Notebook
 
@@ -32,4 +34,4 @@ jupyter notebook covid_heatmap.ipynb
 ```
 
 Executing all cells will display the map inline and save it to
-`covid_bubble_map.html`.
+`covid_dashboard.html`.

--- a/covid_heatmap.ipynb
+++ b/covid_heatmap.ipynb
@@ -61,8 +61,8 @@
    "source": [
     "b = folium.Map(location=[0, 0], zoom_start=2)\n",
     "TimestampedGeoJson({'type': 'FeatureCollection', 'features': features}, period='P1D', add_last_point=False, auto_play=False).add_to(b)\n",
-    "b.save('covid_bubble_map.html')\n",
-    "print(f'Bubble map saved to covid_bubble_map.html for dates {date_cols[0]} to {date_cols[-1]}.')\n",
+    "b.save('covid_dashboard.html')\n",
+    "print(f'Dashboard saved to covid_dashboard.html for dates {date_cols[0]} to {date_cols[-1]}.')\n",
     "b"
   ]
   }

--- a/covid_heatmap.py
+++ b/covid_heatmap.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import argparse
 from math import sqrt
+import json
 
 import folium
 import pandas as pd
@@ -53,6 +54,8 @@ def main() -> None:
     iso_dates = pd.to_datetime(date_cols).strftime("%Y-%m-%d")
 
     features = []
+    table_data: dict[str, list[dict[str, float | int]]] = {iso: [] for iso in iso_dates}
+
     for _, row in grouped.iterrows():
         lat = row["Lat"]
         lon = row["Long"]
@@ -79,6 +82,7 @@ def main() -> None:
                     },
                 }
             )
+            table_data[iso].append({"Lat": float(lat), "Long": float(lon), "Cases": int(count)})
 
     b = folium.Map(location=[0, 0], zoom_start=2, width="80%", height="60%")
     TimestampedGeoJson(
@@ -87,9 +91,45 @@ def main() -> None:
         add_last_point=False,
         auto_play=False,
     ).add_to(b)
-    b.save("covid_bubble_map.html")
+
+    table_json = json.dumps(table_data)
+    options = "".join(f'<option value="{d}">{d}</option>' for d in iso_dates)
+    table_html = f"""
+    <div id=\"table-container\">
+      <label for=\"date-select\">Date:</label>
+      <select id=\"date-select\">{options}</select>
+      <table id=\"data-table\">
+        <thead><tr><th>Latitude</th><th>Longitude</th><th>Cases</th></tr></thead>
+        <tbody id=\"data-tbody\"></tbody>
+      </table>
+    </div>
+    <style>
+    #table-container {{width:80%;margin:20px auto;}}
+    #data-table {{width:100%;border-collapse:collapse;}}
+    #data-table th,#data-table td {{border:1px solid #ccc;padding:4px;text-align:right;}}
+    #data-table th {{background-color:#f0f0f0;}}
+    </style>
+    <script>
+    var tableData = {table_json};
+    var select = document.getElementById('date-select');
+    function render(date) {{
+      var body = document.getElementById('data-tbody');
+      body.innerHTML = '';
+      (tableData[date] || []).forEach(function(row) {{
+        var tr = document.createElement('tr');
+        tr.innerHTML = '<td>'+row.Lat+'</td><td>'+row.Long+'</td><td>'+row.Cases+'</td>';
+        body.appendChild(tr);
+      }});
+    }}
+    select.addEventListener('change', function() {{render(this.value);}});
+    render(select.value);
+    </script>
+    """
+    b.get_root().html.add_child(folium.Element(table_html))
+
+    b.save("covid_dashboard.html")
     print(
-        f"Bubble map saved to covid_bubble_map.html for dates {date_cols[0]} to {date_cols[-1]}."
+        f"Dashboard saved to covid_dashboard.html for dates {date_cols[0]} to {date_cols[-1]}."
     )
 
 


### PR DESCRIPTION
## Summary
- add a table that updates based on the selected date
- update README with new HTML output name and table description
- adjust notebook for new output name

## Testing
- `python -m py_compile covid_heatmap.py`

------
https://chatgpt.com/codex/tasks/task_e_6842f13f2c2083229755a0407d00f766